### PR TITLE
chore: add script to add `admins` group

### DIFF
--- a/os37/admin.bash
+++ b/os37/admin.bash
@@ -1,0 +1,4 @@
+oc adm groups new admins
+oc adm policy add-cluster-role-to-group cluster-admin admins
+oc adm groups add-users admins admin
+


### PR DESCRIPTION
Adds the `admins` group with `cluster-admin` and adds the user `admin`
to it.